### PR TITLE
Remove simply.com

### DIFF
--- a/adguard_cb/src/main/res/raw/filter_200.txt
+++ b/adguard_cb/src/main/res/raw/filter_200.txt
@@ -4542,7 +4542,6 @@ _vpaid^$object-subrequest,script,websocket,xmlhttprequest
 ||similarsites.com^$third-party
 ||simplereach.com^$third-party
 ||simpli.fi^$third-party
-||simply.com^$third-party
 ||simplyhired.com^$third-party
 ||simwebjs.info^
 ||simg.sinajs.cn^


### PR DESCRIPTION
We aquired simply.com and are working on launching a webhosting project on it. However the domain is blocked, due to past advertising activity (before we bought it).